### PR TITLE
Calculate dimensions immediately after mounting the component

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -13,7 +13,10 @@ class Wrapper extends React.Component {
   };
 
   componentDidMount() {
-    this.getDimensions();
+    if (!this.props.height ||
+        !this.props.width) {
+      this.getDimensions();
+    }
 
     if (this.props.responsive) {
       window.addEventListener('resize', this.getDimensions, false);

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -13,6 +13,8 @@ class Wrapper extends React.Component {
   };
 
   componentDidMount() {
+    this.getDimensions();
+
     if (this.props.responsive) {
       window.addEventListener('resize', this.getDimensions, false);
     }


### PR DESCRIPTION
Fix the problem that canvas size is not calculated unless new props are passed if `responsive` prop is `true`